### PR TITLE
Develop

### DIFF
--- a/README.org
+++ b/README.org
@@ -23,7 +23,16 @@ Write 1 =with-plots= and (at least) 1 =gp-setup= per output file.
              :key '(:bottom :right :font "Times New Roman, 6")
              ;; list contents are recursively quoted
              ;; then joined by a space
-             :pointsize "0.4px")
+             :pointsize "0.4px"
+             :yrange :|[0:1]|
+             ; currently, specifying these kinds of options requires to abuse
+             ; keywords and symbols. Another example: comma separated list.
+             ; :terminal '(:pdf :size |10cm,6cm|)
+             )
+
+   ;; unsupported commands can also be used by printing to the stream
+   (format t "~%unset keys")
+
    (func-plot "sin(x)" :title "super sin curve!")
    (plot (lambda ()
            (format t "~&0 0")

--- a/eazy-gnuplot.asd
+++ b/eazy-gnuplot.asd
@@ -20,7 +20,7 @@
   :author "Masataro Asai"
   :mailto "guicho2.71828@gmail.com"
   :license "LLGPL"
-  :depends-on (:iterate :optima :alexandria
+  :depends-on (:iterate :trivia :alexandria
                         #+(and ccl linux)
                         :trivial-shell
                         #-(and ccl linux)

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -6,7 +6,7 @@
 (in-package :cl-user)
 (defpackage eazy-gnuplot
   (:use :cl :iterate
-        :optima
+        :trivia
         :alexandria)
   (:import-from 
    #+(and ccl linux)

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -33,11 +33,16 @@
     ((type string) (format nil "\"~a\"" value))
     ((type pathname) (gp-quote (namestring value)))
     (nil "")
+    ((symbol name)
+     (if (some (conjoin #'both-case-p #'lower-case-p) name)
+         name                           ; escaped characters e.g. |Left|
+         (string-downcase name)))
     ((type list)
      (reduce (lambda (str val)
                (format nil "~a ~a"
                        str (gp-quote val)))
              value))
+    ;; numbers etc
     (_ value)))
 
 (defun gp-map-args (args fn)

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -98,6 +98,8 @@
    *gnuplot-home*
    :input (get-output-stream-string output-string-stream)
    #-(and ccl linux)
+   :verbose t
+   #-(and ccl linux)
    :external-format external-format))
 
 (defun %plot (data-producing-fn &rest args


### PR DESCRIPTION
fixed the handling of escaped symbols e.g. |Left|, which may appear when you use `set key Left` to left-justify the key http://gnuplot.sourceforge.net/docs_4.2/node192.html
