### PR TITLE
Maintain order of sets unsets issue 22

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -18,6 +18,7 @@
            :gp-setup
            :gp-set
            :gp-unset
+           :gp-clear
            :gp-quote
            :*gnuplot-home*
            :row))
@@ -110,7 +111,16 @@ parameter style.
   NIL
 "
   (assert (every #'symbolp args))
-  (format *user-stream* "~&~{~^unset ~a~%~}~%" (mapcar #'gp-quote args)))
+  (format *plot-stream* "~&~{~^unset ~a~%~}~%" (mapcar #'gp-quote args)))
+
+(defun gp-clear ()
+  "gnuplot clear comannd
+- Arguments:
+
+- Return:
+  NIL
+"
+  (format *plot-stream* "~&clear~%"))
 
 (defmacro with-plots ((stream &key debug (external-format :default))
                       &body body)

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -56,7 +56,7 @@
       (funcall fn key value)
       (map-plist rest fn))))
 
-(defun gp-setup (&rest args &key terminal output &allow-other-keys)
+(defun gp-setup (&rest args &key terminal output multiplot &allow-other-keys)
   (let ((*print-case* :downcase))
     (unless output
       (error "missing ouptut!"))
@@ -69,9 +69,9 @@
                 output type))
         ((and type (type string)) 
          (setf terminal (make-keyword type)))))
-    (setf *plot-type-multiplot* (find :multiplot args))
-    (format *user-stream* "~&set ~a ~a" :terminal (gp-quote terminal))
-    (format *user-stream* "~&set ~a ~a" :output (gp-quote output))
+    (setf *plot-type-multiplot* multiplot)
+    (format *plot-stream* "~&set ~a ~a" :terminal (gp-quote terminal))
+    (format *plot-stream* "~&set ~a ~a" :output (gp-quote output))
     (remf args :terminal)
     (remf args :output)
     (apply #'gp-set args)))
@@ -92,7 +92,7 @@ parameter style.
 "
   (map-plist args
              (lambda (key val)
-               (format *user-stream* "~&set ~a ~a"
+               (format *plot-stream* "~&set ~a ~a"
                        key (gp-quote val)))))
 
 (defun gp-unset (&rest args)

--- a/t/package.lisp
+++ b/t/package.lisp
@@ -392,8 +392,7 @@
               :size (list "1,.5")
               :border 0)
       (gp-unset :key
-                :tics
-                :raxis)
+                :tics)
       (func-plot "[pi:2*pi] -1" :lw 5 )
       (gp-set :title "###################"
               :origin (list "0,.5")

--- a/t/package.lisp
+++ b/t/package.lisp
@@ -382,3 +382,24 @@
       (func-plot "besy1(x)")
         (gp-unset 'multiplot))))
 
+(test maintain-order-of-sets-unsets-issue-21
+  (with-fixture test-plot ("maintain-order-of-sets-unsets-issue-21.png")
+    (eazy-gnuplot:with-plots (*standard-output* :debug t)
+         (eazy-gnuplot:gp-setup :output path
+                                :multiplot (list ""))
+      (gp-set :title "O     O"
+              :polar '()
+              :size (list "1,.5")
+              :border 0)
+      (gp-unset :key
+                :tics
+                :raxis)
+      (func-plot "[pi:2*pi] -1" :lw 5 )
+      (gp-set :title "###################"
+              :origin (list "0,.5")
+              :size (list ".5, .5"))
+      (func-plot "-2*pi" :lw (list "2, .2") :with 'filledcurves)
+      (gp-set  :origin (list ".5, .5")
+               :title "###################")
+      (func-plot "1" :lw (list "2, .2") :with 'filledcurves)
+      (gp-unset 'multiplot))))


### PR DESCRIPTION
Output of gp-set and gp-unset is now going to plot stream so it gets rendered inline.
The multiplot marameter must now be set in gp-setup and is now a optional keyword
parameter of gp-setup.
