### PR TITLE
Fix plotting multiple series with the same function

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -262,19 +262,15 @@ multiplot etc."
     ;; ensure the function is called once
     (let ((correct-stream (if *plot-type-multiplot* *plot-command-stream* *data-stream*))
           (*user-stream* (make-string-output-stream)))
-      (flet ((plt ()
-               (terpri correct-stream)
-               (write-sequence (get-output-stream-string *user-stream*)
-                               correct-stream)
-               (format correct-stream "~&end~%")))
-        (unwind-protect
-            (funcall data) ;;; protect against local escape from DATA
-          (prog1
-            (let ((n (count :using args)))
-              (if (> n 0)
-                  (loop repeat n do (plt))
-                  (plt)))
-            (close *user-stream*)))))))
+      (unwind-protect
+          (funcall data) ;;; protect against local escape from DATA
+        (let ((n (count :using args))
+              (data-string (get-output-stream-string *user-stream*)))
+          (close *user-stream*)
+          (loop repeat (if (> n 0) n 1)
+                do (terpri correct-stream)
+                   (write-sequence data-string correct-stream)
+                   (format correct-stream "~&end~%")))))))
 
 (defun plot (data &rest args &key using &allow-other-keys)
   "DATA is either a function producing data, a string


### PR DESCRIPTION
If `plot` gets a function producing data, but multiple `:using` args, it currently reads all the output from the function on the first go, and subsequent `:using` args don't have anything left to plot.

Instead, save the data produced by the function for later, and output it every time.

This should fix #42.

I suppose a better way to do this would be to declare the data once in a gnuplot data block (as mentioned in #42) and then refer to it one or multiple times, but then eazy-gnuplot would require gnuplot >= 5.0.